### PR TITLE
refactor: add simulation adapter

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,3 +9,6 @@
 [submodule "lib/openzeppelin-contracts"]
 	path = lib/openzeppelin-contracts
 	url = https://github.com/openzeppelin/openzeppelin-contracts
+[submodule "lib/call-simulation"]
+	path = lib/call-simulation
+	url = https://github.com/Mean-Finance/call-simulation

--- a/remappings.txt
+++ b/remappings.txt
@@ -2,3 +2,4 @@
 forge-std/=lib/forge-std/src/
 src/=src/
 @openzeppelin/=lib/openzeppelin-contracts/
+@call-simulation/=lib/call-simulation/src

--- a/src/UniversalPermit2Adapter.sol
+++ b/src/UniversalPermit2Adapter.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.8.0;
 
+import { SimulationAdapter } from "@call-simulation/SimulationAdapter.sol";
 // solhint-disable no-unused-import
 import { BasePermit2Adapter, IPermit2, Token } from "./base/BasePermit2Adapter.sol";
 import {
@@ -19,6 +20,6 @@ import { ISwapPermit2Adapter, SwapPermit2Adapter } from "./base/SwapPermit2Adapt
  *      the only tokens approved/transferred through Permit2 should be entirely spent in the same transaction.
  *      Any unspent allowance or remaining tokens on the contract can be transferred by anyone, so please be careful!
  */
-contract UniversalPermit2Adapter is SwapPermit2Adapter, ArbitraryExecutionPermit2Adapter {
+contract UniversalPermit2Adapter is SimulationAdapter, SwapPermit2Adapter, ArbitraryExecutionPermit2Adapter {
   constructor(IPermit2 _permit2) BasePermit2Adapter(_permit2) { }
 }

--- a/src/base/SwapPermit2Adapter.sol
+++ b/src/base/SwapPermit2Adapter.sol
@@ -86,5 +86,4 @@ abstract contract SwapPermit2Adapter is BasePermit2Adapter, ISwapPermit2Adapter 
     // Set amount in
     _amountIn = _params.maxAmountIn - _unspentTokenIn;
   }
-
 }

--- a/src/base/SwapPermit2Adapter.sol
+++ b/src/base/SwapPermit2Adapter.sol
@@ -53,17 +53,6 @@ abstract contract SwapPermit2Adapter is BasePermit2Adapter, ISwapPermit2Adapter 
   }
 
   /// @inheritdoc ISwapPermit2Adapter
-  function sellOrderSwapWithGasMeasurement(SellOrderSwapParams calldata _params)
-    external
-    payable
-    returns (uint256 _amountIn, uint256 _amountOut, uint256 _gasSpent)
-  {
-    uint256 _gasAtStart = gasleft();
-    (_amountIn, _amountOut) = sellOrderSwap(_params);
-    _gasSpent = _gasAtStart - gasleft();
-  }
-
-  /// @inheritdoc ISwapPermit2Adapter
   function buyOrderSwap(BuyOrderSwapParams calldata _params)
     public
     payable
@@ -98,14 +87,4 @@ abstract contract SwapPermit2Adapter is BasePermit2Adapter, ISwapPermit2Adapter 
     _amountIn = _params.maxAmountIn - _unspentTokenIn;
   }
 
-  /// @inheritdoc ISwapPermit2Adapter
-  function buyOrderSwapWithGasMeasurement(BuyOrderSwapParams calldata _params)
-    external
-    payable
-    returns (uint256 _amountIn, uint256 _amountOut, uint256 _gasSpent)
-  {
-    uint256 _gasAtStart = gasleft();
-    (_amountIn, _amountOut) = buyOrderSwap(_params);
-    _gasSpent = _gasAtStart - gasleft();
-  }
 }

--- a/src/interfaces/ISwapPermit2Adapter.sol
+++ b/src/interfaces/ISwapPermit2Adapter.sol
@@ -79,5 +79,4 @@ interface ISwapPermit2Adapter is IBasePermit2Adapter {
     external
     payable
     returns (uint256 amountIn, uint256 amountOut);
-
 }

--- a/src/interfaces/ISwapPermit2Adapter.sol
+++ b/src/interfaces/ISwapPermit2Adapter.sol
@@ -69,21 +69,6 @@ interface ISwapPermit2Adapter is IBasePermit2Adapter {
     returns (uint256 amountIn, uint256 amountOut);
 
   /**
-   * @notice Executes a sell order swap by proxing to another contract, but using Permit2 to transfer tokens from the
-   * caller
-   * @dev Not meant to be used on-chain! The idea behind this function is to have a way to simulate a swap and get
-   *      amount in spent, the amount out received, and the gas spent on the swap. All in one RPC call
-   * @param params The swap's data, such as tokens, amounts, recipient, etc
-   * @return amountIn The amount ot `token in` spent on the swap
-   * @return amountOut The amount of `token out` produced by the proxied swap
-   * @return gasSpent The gas spent on the entire swap
-   */
-  function sellOrderSwapWithGasMeasurement(SellOrderSwapParams calldata params)
-    external
-    payable
-    returns (uint256 amountIn, uint256 amountOut, uint256 gasSpent);
-
-  /**
    * @notice Executes a buy order swap by proxing to another contract, but using Permit2 to transfer tokens from the
    * caller
    * @param params The swap's data, such as tokens, amounts, recipient, etc
@@ -95,18 +80,4 @@ interface ISwapPermit2Adapter is IBasePermit2Adapter {
     payable
     returns (uint256 amountIn, uint256 amountOut);
 
-  /**
-   * @notice Executes a buy order swap by proxing to another contract, but using Permit2 to transfer tokens from the
-   * caller
-   * @dev Not meant to be used on-chain! The idea behind this function is to have a way to simulate a swap and get
-   *      amount in spent, the amount out received, and the gas spent on the swap. All in one RPC call
-   * @param params The swap's data, such as tokens, amounts, recipient, etc
-   * @return amountIn The amount ot `token in` spent on the swap
-   * @return amountOut The amount of `token out` produced by the proxied swap
-   * @return gasSpent The gas spent on the entire swap
-   */
-  function buyOrderSwapWithGasMeasurement(BuyOrderSwapParams calldata params)
-    external
-    payable
-    returns (uint256 amountIn, uint256 amountOut, uint256 gasSpent);
 }

--- a/test/integration/SwapPermit2Adapter.t.sol
+++ b/test/integration/SwapPermit2Adapter.t.sol
@@ -50,7 +50,7 @@ contract SwapPermit2AdapterTest is PRBTest, StdCheats {
 
     // Execute
     vm.prank(alice);
-    (uint256 _returnedAmountIn, uint256 _returnedAmountOut,) = adapter.sellOrderSwapWithGasMeasurement(
+    (uint256 _returnedAmountIn, uint256 _returnedAmountOut) = adapter.sellOrderSwap(
       ISwapPermit2Adapter.SellOrderSwapParams({
         deadline: DEADLINE,
         tokenIn: address(USDC),
@@ -90,7 +90,7 @@ contract SwapPermit2AdapterTest is PRBTest, StdCheats {
 
     // Execute
     vm.prank(alice);
-    (uint256 _returnedAmountIn, uint256 _returnedAmountOut,) = adapter.sellOrderSwapWithGasMeasurement{
+    (uint256 _returnedAmountIn, uint256 _returnedAmountOut) = adapter.sellOrderSwap{
       value: _amountToSwap
     }(
       ISwapPermit2Adapter.SellOrderSwapParams({
@@ -135,7 +135,7 @@ contract SwapPermit2AdapterTest is PRBTest, StdCheats {
 
     // Execute
     vm.prank(alice);
-    (uint256 _returnedAmountIn, uint256 _returnedAmountOut,) = adapter.buyOrderSwapWithGasMeasurement(
+    (uint256 _returnedAmountIn, uint256 _returnedAmountOut) = adapter.buyOrderSwap(
       ISwapPermit2Adapter.BuyOrderSwapParams({
         deadline: DEADLINE,
         tokenIn: address(DAI),

--- a/test/integration/SwapPermit2Adapter.t.sol
+++ b/test/integration/SwapPermit2Adapter.t.sol
@@ -90,9 +90,7 @@ contract SwapPermit2AdapterTest is PRBTest, StdCheats {
 
     // Execute
     vm.prank(alice);
-    (uint256 _returnedAmountIn, uint256 _returnedAmountOut) = adapter.sellOrderSwap{
-      value: _amountToSwap
-    }(
+    (uint256 _returnedAmountIn, uint256 _returnedAmountOut) = adapter.sellOrderSwap{ value: _amountToSwap }(
       ISwapPermit2Adapter.SellOrderSwapParams({
         deadline: DEADLINE,
         tokenIn: address(0),


### PR DESCRIPTION
Instead of using `sellOrderSwapWithGasMeasurement` or `buyOrderSwapWithGasMeasurement`, we just added the new Simulation Adapter. This will allow us to simulate multiple quotes in only one `eth_call` 🔥 