### PR TITLE
refactor: remove msg value

### DIFF
--- a/src/base/SwapPermit2Adapter.sol
+++ b/src/base/SwapPermit2Adapter.sol
@@ -37,7 +37,8 @@ abstract contract SwapPermit2Adapter is BasePermit2Adapter, ISwapPermit2Adapter 
     _params.tokenIn.maxApproveIfNecessary(_params.allowanceTarget);
 
     // Execute swap
-    _params.swapper.functionCallWithValue(_params.swapData, msg.value);
+    uint256 _value = _params.tokenIn == Token.NATIVE_TOKEN ? _params.amountIn : 0;
+    _params.swapper.functionCallWithValue(_params.swapData, _value);
 
     // Distribute token out
     _amountOut = _params.tokenOut.distributeTo(_params.transferOut);
@@ -66,7 +67,8 @@ abstract contract SwapPermit2Adapter is BasePermit2Adapter, ISwapPermit2Adapter 
     _params.tokenIn.maxApproveIfNecessary(_params.allowanceTarget);
 
     // Execute swap
-    _params.swapper.functionCallWithValue(_params.swapData, msg.value);
+    uint256 _value = _params.tokenIn == Token.NATIVE_TOKEN ? _params.maxAmountIn : 0;
+    _params.swapper.functionCallWithValue(_params.swapData, _value);
 
     // Check balance for unspent tokens
     uint256 _unspentTokenIn = _params.tokenIn.balanceOnContract();

--- a/src/libraries/Permit2Transfers.sol
+++ b/src/libraries/Permit2Transfers.sol
@@ -10,7 +10,6 @@ import { Token } from "./Token.sol";
  * @notice A small library to call Permit2's transfer from methods
  */
 library Permit2Transfers {
-
   /**
    * @notice Executes a transfer from using Permit2
    * @param _permit2 The Permit2 contract

--- a/src/libraries/Permit2Transfers.sol
+++ b/src/libraries/Permit2Transfers.sol
@@ -10,12 +10,6 @@ import { Token } from "./Token.sol";
  * @notice A small library to call Permit2's transfer from methods
  */
 library Permit2Transfers {
-  /**
-   * @notice Thrown when received an inexpected amount of native token
-   * @param received The amount of native token received
-   * @param expected The amount of token out expected
-   */
-  error InvalidNativeAmount(uint256 received, uint256 expected);
 
   /**
    * @notice Executes a transfer from using Permit2
@@ -54,8 +48,6 @@ library Permit2Transfers {
         // the EIP712 hash of `permit`.
         _signature
       );
-    } else if (msg.value != _amount) {
-      revert InvalidNativeAmount(msg.value, _amount);
     }
   }
 

--- a/test/unit/SwapPermit2Adapter.t.sol
+++ b/test/unit/SwapPermit2Adapter.t.sol
@@ -5,7 +5,6 @@ import { PRBTest } from "@prb/test/PRBTest.sol";
 import { StdUtils } from "forge-std/StdUtils.sol";
 import { ISwapPermit2Adapter, Token } from "../../src/interfaces/ISwapPermit2Adapter.sol";
 import { IBasePermit2Adapter } from "../../src/interfaces/IBasePermit2Adapter.sol";
-import { Permit2Transfers } from "../../src/libraries/Permit2Transfers.sol";
 import { MockPermit2 } from "./mocks/MockPermit2.sol";
 import { MockERC20 } from "./mocks/MockERC20.sol";
 import { SwapPermit2AdapterInstance } from "./instances/SwapPermit2AdapterInstance.sol";

--- a/test/unit/SwapPermit2Adapter.t.sol
+++ b/test/unit/SwapPermit2Adapter.t.sol
@@ -95,33 +95,6 @@ contract SwapPermit2AdapterTest is PRBTest, StdUtils {
     assertEq(_returnAmountOut, _amountOut, "Invalid return value for amount out");
   }
 
-  // solhint-disable-next-line max-line-length
-  function testFuzz_sellOrderSwap_RevertWhen_NativeAmountIsInvalid(uint256 _amountIn, uint256 _expectedAmountIn) public {
-    vm.assume(_amountIn != _expectedAmountIn);
-    vm.deal(alice, _amountIn);
-
-    // Prepare execution
-    ISwapPermit2Adapter.SellOrderSwapParams memory _params = ISwapPermit2Adapter.SellOrderSwapParams({
-      deadline: type(uint256).max,
-      tokenIn: address(0),
-      amountIn: _expectedAmountIn,
-      nonce: 0,
-      signature: "",
-      allowanceTarget: address(0),
-      swapper: address(swapper),
-      swapData: abi.encodeWithSelector(swapper.swap.selector, address(0), _amountIn, address(tokenOut), 0),
-      tokenOut: address(tokenOut),
-      minAmountOut: 0,
-      transferOut: Utils.buildDistribution(alice)
-    });
-
-    // Prepare expectations and execute
-    // solhint-disable-next-line max-line-length
-    vm.expectRevert(abi.encodeWithSelector(Permit2Transfers.InvalidNativeAmount.selector, _amountIn, _expectedAmountIn));
-    vm.prank(alice);
-    adapter.sellOrderSwap{ value: _amountIn }(_params);
-  }
-
   function testFuzz_sellOrderSwap_RevertWhen_NativeToERC20DoesNotReturnEnoughTokenOut(
     uint256 _amountIn,
     uint256 _amountOut
@@ -329,33 +302,6 @@ contract SwapPermit2AdapterTest is PRBTest, StdUtils {
     assertEq(tokenOut.balanceOf(alice), _amountOut, "Token out not sent to alice");
     assertEq(_returnAmountIn, _amountIn, "Invalid returned value for amount in");
     assertEq(_returnAmountOut, _amountOut, "Invalid return value for amount out");
-  }
-
-  function testFuzz_buyOrderSwap_RevertWhen_NativeAmountIsInvalid(uint256 _amountIn, uint256 _expectedAmountIn) public {
-    vm.assume(_amountIn != _expectedAmountIn);
-    vm.deal(alice, _amountIn);
-
-    // Prepare execution
-    ISwapPermit2Adapter.BuyOrderSwapParams memory _params = ISwapPermit2Adapter.BuyOrderSwapParams({
-      deadline: type(uint256).max,
-      tokenIn: address(0),
-      maxAmountIn: _expectedAmountIn,
-      nonce: 0,
-      signature: "",
-      allowanceTarget: address(0),
-      swapper: address(swapper),
-      swapData: abi.encodeWithSelector(swapper.swap.selector, address(0), _amountIn, address(tokenOut), 0),
-      tokenOut: address(tokenOut),
-      amountOut: 0,
-      transferOut: Utils.buildDistribution(alice),
-      unspentTokenInRecipient: address(0)
-    });
-
-    // Prepare expectations and execute
-    // solhint-disable-next-line max-line-length
-    vm.expectRevert(abi.encodeWithSelector(Permit2Transfers.InvalidNativeAmount.selector, _amountIn, _expectedAmountIn));
-    vm.prank(alice);
-    adapter.buyOrderSwap{ value: _amountIn }(_params);
   }
 
   function testFuzz_buyOrderSwap_RevertWhen_NativeToERC20DoesNotReturnEnoughTokenOut(


### PR DESCRIPTION
Instead of relying on `msg.value`, we are now simply using the input parameters to calculate it. This is because we might need different inputs on the simulation multicall