### PR TITLE
refactor: use permit2 if signature is not empty

### DIFF
--- a/script/Base.s.sol
+++ b/script/Base.s.sol
@@ -4,12 +4,10 @@ pragma solidity >=0.8.19;
 import { Script } from "forge-std/Script.sol";
 
 abstract contract BaseScript is Script {
-
   /// @dev Needed for the deterministic deployments.
   bytes32 internal constant ZERO_SALT = bytes32(0);
 
-  constructor() {
-  }
+  constructor() { }
 
   modifier broadcaster() {
     vm.startBroadcast();

--- a/script/Base.s.sol
+++ b/script/Base.s.sol
@@ -4,25 +4,15 @@ pragma solidity >=0.8.19;
 import { Script } from "forge-std/Script.sol";
 
 abstract contract BaseScript is Script {
-  /// @dev Included to enable compilation of the script without a $MNEMONIC environment variable.
-  string internal constant TEST_MNEMONIC = "test test test test test test test test test test test junk";
 
   /// @dev Needed for the deterministic deployments.
   bytes32 internal constant ZERO_SALT = bytes32(0);
 
-  /// @dev The address of the contract deployer.
-  address internal deployer;
-
-  /// @dev Used to derive the deployer's address.
-  string internal mnemonic;
-
   constructor() {
-    mnemonic = vm.envOr("MNEMONIC", TEST_MNEMONIC);
-    (deployer,) = deriveRememberKey({ mnemonic: mnemonic, index: 4 });
   }
 
   modifier broadcaster() {
-    vm.startBroadcast(deployer);
+    vm.startBroadcast();
     _;
     vm.stopBroadcast();
   }

--- a/src/libraries/Permit2Transfers.sol
+++ b/src/libraries/Permit2Transfers.sol
@@ -29,7 +29,7 @@ library Permit2Transfers {
   )
     internal
   {
-    if (address(_token) != Token.NATIVE_TOKEN) {
+    if (_signature.length > 0) {
       _permit2.permitTransferFrom(
         // The permit message.
         IPermit2.PermitTransferFrom({

--- a/test/unit/ArbitraryExecutionPermit2Adapter.t.sol
+++ b/test/unit/ArbitraryExecutionPermit2Adapter.t.sol
@@ -116,6 +116,7 @@ contract ArbitraryExecutionPermit2AdapterTest is PRBTest, StdUtils {
   )
     public
   {
+    vm.assume(_signature.length > 0);
     // Give alice some tokens
     tokenIn.mint(alice, _tokenInAmount);
 

--- a/test/unit/SwapPermit2Adapter.t.sol
+++ b/test/unit/SwapPermit2Adapter.t.sol
@@ -184,6 +184,7 @@ contract SwapPermit2AdapterTest is PRBTest, StdUtils {
   )
     public
   {
+    vm.assume(_signature.length > 0);
     tokenIn.mint(alice, _amountIn);
     vm.deal(address(swapper), _amountOut);
 
@@ -238,6 +239,7 @@ contract SwapPermit2AdapterTest is PRBTest, StdUtils {
   )
     public
   {
+    vm.assume(_signature.length > 0);
     _amountOut = bound(_amountOut, 0, type(uint256).max - 1);
 
     tokenIn.mint(alice, _amountIn);
@@ -448,6 +450,7 @@ contract SwapPermit2AdapterTest is PRBTest, StdUtils {
   )
     public
   {
+    vm.assume(_signature.length > 0);
     tokenIn.mint(alice, _amountIn);
     vm.deal(address(swapper), _amountOut);
 
@@ -503,6 +506,7 @@ contract SwapPermit2AdapterTest is PRBTest, StdUtils {
   )
     public
   {
+    vm.assume(_signature.length > 0);
     _amountOut = bound(_amountOut, 0, type(uint256).max - 1);
 
     tokenIn.mint(alice, _amountIn);
@@ -624,6 +628,7 @@ contract SwapPermit2AdapterTest is PRBTest, StdUtils {
   )
     public
   {
+    vm.assume(_signature.length > 0);
     vm.assume(_maxAmountIn > 1);
     _amountUsed = bound(_amountUsed, 1, _maxAmountIn - 1);
 


### PR DESCRIPTION
Before this change, we would determine if we were going to use Permit2 to take funds from the caller by checking if the `tokenIn` was the native token or not.

The thing is that in some corner cases, we were able to send tokens from the caller directly to this contract before calling the adapter. By doing this, we could save an ERC20 transfer

But, the contract would still try to use Permit2 since `tokenIn` was not the native token. So the idea is to use another way to detect if we want to use Permit2 or not. We will use Permit2 if the signature is not empty. If it is empty, then calling Permit2 would fail anyway

So now, we can set `tokenIn` to an ERC20, but avoid using Permit2 by setting an empty signature