### PR TITLE
feat: support erc 1271

### DIFF
--- a/src/base/BasePermit2Adapter.sol
+++ b/src/base/BasePermit2Adapter.sol
@@ -30,14 +30,12 @@ abstract contract BasePermit2Adapter is IBasePermit2Adapter, IERC1271 {
   receive() external payable { }
 
   function isValidSignature(bytes32, bytes memory) external view returns (bytes4 magicValue) {
-    // Note: both swap and arbitrary adapters support approving tokens for other addresses, for integrations to work. The 
-    //       thing is that sometimes, these third party contracts use Permit2 instead of using ERC20's transfer from. When 
-    //       that happens, the allowance target will need to be the Permit2 contract, and then Permit2 will call this function 
-    //       to make sure we authorize the  extraction of tokens. Since this contract is not meant to hold any funds outside 
-    //       of the scope of a swap or arbitrary execution, we'll allow it
-    return msg.sender == address(PERMIT2)
-      ? MAGIC_WORD
-      : bytes4(0) ;
+    // Note: both swap and arbitrary adapters support approving tokens for other addresses, for integrations to work. The
+    //       thing is that sometimes, these third party contracts use Permit2 instead of using ERC20's transfer from.
+    //       When that happens, the allowance target will need to be the Permit2 contract, and then Permit2 will call
+    //       this function to make sure we authorize the  extraction of tokens. Since this contract is not meant to hold
+    //       any funds outside of the scope of a swap or arbitrary execution, we'll allow it
+    return msg.sender == address(PERMIT2) ? MAGIC_WORD : bytes4(0);
   }
 
   modifier checkDeadline(uint256 _deadline) {

--- a/src/base/BasePermit2Adapter.sol
+++ b/src/base/BasePermit2Adapter.sol
@@ -1,16 +1,17 @@
 // SPDX-License-Identifier: GPL-2.0-or-later
 pragma solidity >=0.8.0;
 
+import { Address } from "@openzeppelin/contracts/utils/Address.sol";
+import { IERC1271 } from "@openzeppelin/contracts/interfaces/IERC1271.sol";
 import { IBasePermit2Adapter, IPermit2 } from "../interfaces/IBasePermit2Adapter.sol";
 import { Token } from "../libraries/Token.sol";
-import { Address } from "@openzeppelin/contracts/utils/Address.sol";
 
 /**
  * @title Base Permit2 Adapter
  * @author Sam Bugs
  * @notice The base contract for Permit2 adapters
  */
-abstract contract BasePermit2Adapter is IBasePermit2Adapter {
+abstract contract BasePermit2Adapter is IBasePermit2Adapter, IERC1271 {
   using Address for address;
 
   /// @inheritdoc IBasePermit2Adapter
@@ -19,12 +20,25 @@ abstract contract BasePermit2Adapter is IBasePermit2Adapter {
   // solhint-disable-next-line var-name-mixedcase
   IPermit2 public immutable PERMIT2;
 
+  bytes4 private constant MAGIC_WORD = IERC1271.isValidSignature.selector;
+
   constructor(IPermit2 _permit2) {
     PERMIT2 = _permit2;
   }
 
   // solhint-disable-next-line no-empty-blocks
   receive() external payable { }
+
+  function isValidSignature(bytes32, bytes memory) external view returns (bytes4 magicValue) {
+    // Note: both swap and arbitrary adapters support approving tokens for other addresses, for integrations to work. The 
+    //       thing is that sometimes, these thrid party contracts use Permit2 instead of using ERC20's transfer from. When 
+    //       that happens, the allowance target will need to be the Permit2 contract, and then Permit2 will call this function 
+    //       to make sure we authorize the  extraction of tokens. Since this contract is not meant to hold any funds outside 
+    //       of the scope of a swap or arbitrary execution, we'll allow it
+    return msg.sender == address(PERMIT2)
+      ? MAGIC_WORD
+      : bytes4(0) ;
+  }
 
   modifier checkDeadline(uint256 _deadline) {
     if (block.timestamp > _deadline) revert TransactionDeadlinePassed(block.timestamp, _deadline);

--- a/src/base/BasePermit2Adapter.sol
+++ b/src/base/BasePermit2Adapter.sol
@@ -31,7 +31,7 @@ abstract contract BasePermit2Adapter is IBasePermit2Adapter, IERC1271 {
 
   function isValidSignature(bytes32, bytes memory) external view returns (bytes4 magicValue) {
     // Note: both swap and arbitrary adapters support approving tokens for other addresses, for integrations to work. The 
-    //       thing is that sometimes, these thrid party contracts use Permit2 instead of using ERC20's transfer from. When 
+    //       thing is that sometimes, these third party contracts use Permit2 instead of using ERC20's transfer from. When 
     //       that happens, the allowance target will need to be the Permit2 contract, and then Permit2 will call this function 
     //       to make sure we authorize the  extraction of tokens. Since this contract is not meant to hold any funds outside 
     //       of the scope of a swap or arbitrary execution, we'll allow it

--- a/test/unit/BasePermit2Adapter.t.sol
+++ b/test/unit/BasePermit2Adapter.t.sol
@@ -7,7 +7,6 @@ import { BasePermit2Adapter, IERC1271 } from "../../src/base/BasePermit2Adapter.
 import { MockPermit2, IPermit2 } from "./mocks/MockPermit2.sol";
 
 contract BasePermit2AdapterTest is PRBTest, StdUtils {
-  
   MockPermit2 internal permit2;
   BasePermit2Adapter internal adapter;
 
@@ -16,7 +15,12 @@ contract BasePermit2AdapterTest is PRBTest, StdUtils {
     adapter = new Impl(permit2);
   }
 
-  function testFuzz_isValidSignature_DoesNotReturnMagicWordWhenNotPermit2(bytes32 _hash, bytes memory _signature) public {
+  function testFuzz_isValidSignature_DoesNotReturnMagicWordWhenNotPermit2(
+    bytes32 _hash,
+    bytes memory _signature
+  )
+    public
+  {
     assertNotEq(adapter.isValidSignature(_hash, _signature), IERC1271.isValidSignature.selector);
   }
 
@@ -27,5 +31,5 @@ contract BasePermit2AdapterTest is PRBTest, StdUtils {
 }
 
 contract Impl is BasePermit2Adapter {
-  constructor(IPermit2 permit2) BasePermit2Adapter(permit2) {}
- }
+  constructor(IPermit2 permit2) BasePermit2Adapter(permit2) { }
+}

--- a/test/unit/BasePermit2Adapter.t.sol
+++ b/test/unit/BasePermit2Adapter.t.sol
@@ -1,0 +1,31 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity >=0.8.0;
+
+import { PRBTest } from "@prb/test/PRBTest.sol";
+import { StdUtils } from "forge-std/StdUtils.sol";
+import { BasePermit2Adapter, IERC1271 } from "../../src/base/BasePermit2Adapter.sol";
+import { MockPermit2, IPermit2 } from "./mocks/MockPermit2.sol";
+
+contract BasePermit2AdapterTest is PRBTest, StdUtils {
+  
+  MockPermit2 internal permit2;
+  BasePermit2Adapter internal adapter;
+
+  function setUp() public virtual {
+    permit2 = new MockPermit2();
+    adapter = new Impl(permit2);
+  }
+
+  function testFuzz_isValidSignature_DoesNotReturnMagicWordWhenNotPermit2(bytes32 _hash, bytes memory _signature) public {
+    assertNotEq(adapter.isValidSignature(_hash, _signature), IERC1271.isValidSignature.selector);
+  }
+
+  function testFuzz_isValidSignature_ReturnsMagicWordWhenPermit2(bytes32 _hash, bytes memory _signature) public {
+    vm.prank(address(permit2));
+    assertEq(adapter.isValidSignature(_hash, _signature), IERC1271.isValidSignature.selector);
+  }
+}
+
+contract Impl is BasePermit2Adapter {
+  constructor(IPermit2 permit2) BasePermit2Adapter(permit2) {}
+ }


### PR DESCRIPTION
Both swap and arbitrary adapters support approving tokens for other addresses, for integrations to work. The thing is that sometimes, these third party contracts use Permit2 instead of using ERC20's transfer from. When that happens, the allowance target will need to be the Permit2 contract, and then Permit2 will call this function  to make sure we authorize the  extraction of tokens. Since this contract is not meant to hold any funds outside of the scope of a swap or arbitrary execution, we'll allow it